### PR TITLE
fix: nuxt aliases definitions

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -448,12 +448,9 @@ export default defineNuxtModule<ModuleOptions>({
     const nuxtOptions = nuxt.options
     nuxtOptions.alias = nuxtOptions.alias ?? {}
 
-    if (hasQueries)
-      nuxtOptions.alias['#edgedb/queries'] = queriesPath
-    if (hasInterfaces)
-      nuxtOptions.alias['#edgedb/interfaces'] = interfacesPath
-    if (hasQueryBuilder)
-      nuxtOptions.alias['#edgedb/builder'] = builderPath
+    nuxtOptions.alias['#edgedb/queries'] = queriesPath
+    nuxtOptions.alias['#edgedb/interfaces'] = interfacesPath
+    nuxtOptions.alias['#edgedb/builder'] = builderPath
 
     if (!nuxt.options._prepare) {
       await generateInterfaces()


### PR DESCRIPTION
Always add nuxt aliases to avoid warnings of unresolvable like:

```
// [5:44:13 PM]  WARN  "#edgedb/queries" is imported by "../../../nuxt-edgedb/dist/runtime/server/composables/useEdgeDbQueries.mjs", but could not be resolved – treating it as an external dependency.
```