### PR TITLE
fix: adopt forward-compatible approach to `builder:watch`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,3 +1,4 @@
+import { relative, resolve } from 'node:path'
 import { existsSync } from 'node:fs'
 import type { NuxtModule } from 'nuxt/schema'
 import { addComponentsDir, addImports, addPlugin, addServerHandler, addServerImports, addServerPlugin, createResolver, defineNuxtModule } from '@nuxt/kit'
@@ -317,6 +318,7 @@ const nuxtModule = defineNuxtModule<ModuleOptions>({
       nuxt.options.watch.push(`${queriesDir}/*`)
 
       nuxt.hook('builder:watch', async (event, path) => {
+        path = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, path))
         if (event === 'add' || event === 'change' || event === 'unlink' || event === 'unlinkDir') {
           // Queries
           if (path.includes(options.queriesDir) && path.endsWith('.edgeql')) {


### PR DESCRIPTION
We are planning to move to [emitting absolute paths in `builder:watch` in Nuxt v4](https://github.com/nuxt/nuxt/issues/25339). You can see a little more about the history in the PR linked in that issue.

This PR is an attempt to use a forward/backward compatible approach, namely resolving the path to ensure it's absolute, then making it relative so your existing code will continue to work.

This should be safe to merge as is, but do let me know if you have any concerns about this approach.

