### PR TITLE
chore: update to latest `@nuxt/module-builder`

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@antfu/eslint-config": "^2.21.1",
     "@nuxt/devtools": "latest",
-    "@nuxt/module-builder": "^0.7.1",
+    "@nuxt/module-builder": "^0.8.3",
     "@nuxt/schema": "^3.12.2",
     "@nuxt/test-utils": "^3.13.1",
     "@types/node": "^20.14.3",


### PR DESCRIPTION
Previous versions of `@nuxt/module-builder` produced incorrect types for files in the `runtime/` directory. Specifically, a `.d.ts` declaration paired with a `.mjs` file. This isn't correct - it should be either `.d.mts`  and `.mjs` or `.d.ts` and `.js`. 

For maximum compatibility, `@nuxt/module-builder` v0.8 switched to `.js` extension for files in `runtime/` directory.

With the latest Nuxt, this is now an error that removes correct plugin injection types.

Related PRs: https://github.com/nuxt/nuxt/pull/28480, https://github.com/nuxt/nuxt/pull/28593
See also https://github.com/nuxt/nuxt/issues/28672.